### PR TITLE
feat: make IconImageView initializer public

### DIFF
--- a/Sources/UIKitPro/UI/ImageView/IconImageView.swift
+++ b/Sources/UIKitPro/UI/ImageView/IconImageView.swift
@@ -18,7 +18,7 @@ public class IconImageView: UIImageView {
     private var color: UIColor
     
     // MARK: - Initializer
-    init(
+    public init(
         systemName: String,
         color: UIColor,
         pointSize: CGFloat = 20,


### PR DESCRIPTION
Change the initializer of IconImageView to public to allow external modules to create instances.