### PR TITLE
chore: comment out UIView asButton extension

### DIFF
--- a/Sources/UIKitPro/UI/UIView/UIView+AsButton.swift
+++ b/Sources/UIKitPro/UI/UIView/UIView+AsButton.swift
@@ -7,21 +7,21 @@
 //         
 
 import UIKit
-
-extension UIView {
-    public func asButton(action: @escaping () -> Void) {
-        self.isUserInteractionEnabled = true
-        let tapRecognizer = TapGestureRecognizer(target: self, action: #selector(handleTap))
-        tapRecognizer.action = action
-        tapRecognizer.cancelsTouchesInView = false
-        self.addGestureRecognizer(tapRecognizer)
-    }
-    
-    @objc private func handleTap(_ sender: TapGestureRecognizer) {
-        sender.action?()
-    }
-}
-
-private class TapGestureRecognizer: UITapGestureRecognizer {
-    var action: (() -> Void)?
-}
+//
+//extension UIView {
+//    public func asButton(action: @escaping () -> Void) {
+//        self.isUserInteractionEnabled = true
+//        let tapRecognizer = TapGestureRecognizer(target: self, action: #selector(handleTap))
+//        tapRecognizer.action = action
+//        tapRecognizer.cancelsTouchesInView = false
+//        self.addGestureRecognizer(tapRecognizer)
+//    }
+//    
+//    @objc private func handleTap(_ sender: TapGestureRecognizer) {
+//        sender.action?()
+//    }
+//}
+//
+//private class TapGestureRecognizer: UITapGestureRecognizer {
+//    var action: (() -> Void)?
+//}


### PR DESCRIPTION
Temporarily disable the UIView extension that adds an asButton method with a custom tap gesture recognizer. This change is done to prevent potential issues or conflicts while retaining the code for future reference or reactivation.