### PR TITLE
fix(UIView+Stacking): provide default empty array for views parameter

### DIFF
--- a/Sources/UIKitPro/UI/UIView/UIView+Stacking.swift
+++ b/Sources/UIKitPro/UI/UIView/UIView+Stacking.swift
@@ -13,7 +13,7 @@ import UIKit
 extension UIView {
     fileprivate func _stack(
         _ axis: NSLayoutConstraint.Axis = .vertical,
-        views: [UIView],
+        views: [UIView] = [],
         spacing: CGFloat = 0,
         alignment: UIStackView.Alignment = .fill,
         distribution: UIStackView.Distribution = .fill


### PR DESCRIPTION
Add a default empty array value to the views parameter in the _stack method to simplify calls when no views are provided. This improves API usability by making the parameter optional and avoiding the need to explicitly pass an empty array.