### PR TITLE
fix: update default parameters for stacking methods

### DIFF
--- a/Sources/UIKitPro/UI/UIStackView.swift
+++ b/Sources/UIKitPro/UI/UIStackView.swift
@@ -11,7 +11,7 @@ import UIKit
 @available(iOS 11.0, tvOS 11.0, *)
 extension UIStackView {
     public convenience init(
-        arrangedSubviews: [UIView],
+        arrangedSubviews: [UIView] = [],
         axis: NSLayoutConstraint.Axis = .vertical,
         spacing: CGFloat = 0,
         alignment: UIStackView.Alignment = .fill,

--- a/Sources/UIKitPro/UI/UIView/UIView+Stacking.swift
+++ b/Sources/UIKitPro/UI/UIView/UIView+Stacking.swift
@@ -13,7 +13,7 @@ import UIKit
 extension UIView {
     fileprivate func _stack(
         _ axis: NSLayoutConstraint.Axis = .vertical,
-        views: [UIView] = [],
+        views: [UIView],
         spacing: CGFloat = 0,
         alignment: UIStackView.Alignment = .fill,
         distribution: UIStackView.Distribution = .fill


### PR DESCRIPTION
Remove default empty array from UIView._stack's views parameter to require explicit views input, improving clarity and preventing accidental empty stacks. Add default empty array to UIStackView convenience initializer's arrangedSubviews parameter to allow initialization without specifying subviews, enhancing flexibility.